### PR TITLE
Errors if LaunchConfigurationName is empty string

### DIFF
--- a/amicleaner/fetch.py
+++ b/amicleaner/fetch.py
@@ -67,7 +67,7 @@ class Fetcher(object):
         resp = self.asg.describe_auto_scaling_groups()
         zeroed_lcs = [asg.get("LaunchConfigurationName", "")
                       for asg in resp.get("AutoScalingGroups", [])
-                      if asg.get("DesiredCapacity", 0) == 0]
+                      if asg.get("DesiredCapacity", 0) == 0 and asg.get("LaunchConfigurationName", "")]
 
         resp = self.asg.describe_launch_configurations(
             LaunchConfigurationNames=zeroed_lcs


### PR DESCRIPTION
Got the following error where `zeroed_lcs = ['']` and gave the below error. Likely because of the use of LaunchTemplates instead of LaunchConfigurations.

Fixes the below error:
```
  File "/usr/local/lib/python3.5/dist-packages/amicleaner/cli.py", line 53, in fetch_candidates
    excluded_amis += f.fetch_zeroed_asg()
  File "/usr/local/lib/python3.5/dist-packages/amicleaner/fetch.py", line 72, in fetch_zeroed_asg
    LaunchConfigurationNames=zeroed_lcs
  File "/usr/local/lib/python3.5/dist-packages/botocore/client.py", line 276, in _api_call
    return self._make_api_call(operation_name, kwargs)
  File "/usr/local/lib/python3.5/dist-packages/botocore/client.py", line 559, in _make_api_call
    api_params, operation_model, context=request_context)
  File "/usr/local/lib/python3.5/dist-packages/botocore/client.py", line 607, in _convert_to_request_dict
    api_params, operation_model)
  File "/usr/local/lib/python3.5/dist-packages/botocore/validate.py", line 297, in serialize_to_request
    raise ParamValidationError(report=report.generate_report())
botocore.exceptions.ParamValidationError: Parameter validation failed:
Invalid length for parameter LaunchConfigurationNames[0], value: 0, valid range: 1-inf
```